### PR TITLE
Fixes font replacement for Android 6.0 (Marshmallow)

### DIFF
--- a/KanjiFix/build.gradle
+++ b/KanjiFix/build.gradle
@@ -13,8 +13,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     compileOptions {
         encoding "UTF-8"
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 23
     }
 }
 

--- a/KanjiFix/src/main/java/com/ascendtv/kanjifix/FallbackXmlFile.java
+++ b/KanjiFix/src/main/java/com/ascendtv/kanjifix/FallbackXmlFile.java
@@ -32,7 +32,7 @@ public class FallbackXmlFile {
                     "        <font weight=\"400\" style=\"normal\">NotoSansJP-Regular.otf</font>\n" +
                     "    </family>";
             droidAlternateFont = "    <family lang=\"ja\">\n" +
-                    "        <font weight=\"400\" style=\"normal\">MTLmr3m.ttf</font>\n" +
+                    "        <font weight=\"400\" style=\"normal\">IPAGothic.ttf</font>\n" +
                     "    </family>";
         }
         else if (SDK_INT >= Build.VERSION_CODES.LOLLIPOP) { // 5.0-6.0

--- a/KanjiFix/src/main/java/com/ascendtv/kanjifix/FallbackXmlFile.java
+++ b/KanjiFix/src/main/java/com/ascendtv/kanjifix/FallbackXmlFile.java
@@ -24,8 +24,18 @@ public class FallbackXmlFile {
 
         int SDK_INT = Build.VERSION.SDK_INT;
 
-        if (SDK_INT >= Build.VERSION_CODES.LOLLIPOP) { // 5.0+
-
+        if (SDK_INT >= Build.VERSION_CODES.M) { // 6.0+
+            droidReplaceFont = "    <family lang=\"zh-Hans\">\n" +
+                    "        <font weight=\"400\" style=\"normal\">NotoSansSC-Regular.otf</font>\n" +
+                    "    </family>";
+            droidJapaneseFont = "    <family lang=\"ja\">\n" +
+                    "        <font weight=\"400\" style=\"normal\">NotoSansJP-Regular.otf</font>\n" +
+                    "    </family>";
+            droidAlternateFont = "    <family lang=\"ja\">\n" +
+                    "        <font weight=\"400\" style=\"normal\">MTLmr3m.ttf</font>\n" +
+                    "    </family>";
+        }
+        else if (SDK_INT >= Build.VERSION_CODES.LOLLIPOP) { // 5.0-6.0
             droidReplaceFont = "    <family lang=\"zh-Hans\">\n" +
                     "        <font weight=\"400\" style=\"normal\">NotoSansHans-Regular.otf</font>\n" +
                     "    </family>";


### PR DESCRIPTION
The fonts changed in Android 6.0, so it was failing with the error of "Couldn't find expected fonts in fallback_fonts.xml". This update makes it work again. Tested on a (rooted) Nexus 5 only.
